### PR TITLE
PN counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Thoroughly tested serializable practical CRDT's ported from riak_dt.
 - [ ] Map
 - [ ] G-Set
 - [ ] OR-Set
-- [ ] PN-Counter
+- [x] PN-Counter
 - [ ] EM-Counter
 
 

--- a/src/gcounter.rs
+++ b/src/gcounter.rs
@@ -60,6 +60,24 @@ impl<A: Ord + Clone + Encodable + Decodable> GCounter<A> {
     pub fn value(&self) -> u64 {
         self.inner.dots.values().fold(0, |acc, count| acc + count)
     }
+
+    /// Merge another gcounter into this one, without
+    /// regard to dominance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crdts::GCounter;
+    /// let (mut a, mut b, mut c) = (GCounter::new(), GCounter::new(), GCounter::new());
+    /// a.increment("A".to_string());
+    /// b.increment("B".to_string());
+    /// c.increment("A".to_string());
+    /// c.increment("B".to_string());
+    /// a.merge(b);
+    /// assert_eq!(a, c);
+    pub fn merge(&mut self, other: GCounter<A>) {
+        self.inner.merge(other.inner);
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use vclock::VClock;
 pub use orswot::Orswot;
 pub use lwwreg::LWWReg;
 pub use gcounter::GCounter;
+pub use pncounter::PNCounter;
 
 /// `lwwreg` contains the last-write-wins register.
 pub mod lwwreg;
@@ -16,6 +17,8 @@ pub mod vclock;
 pub mod orswot;
 /// `gcounter` contains the grow-only counter
 pub mod gcounter;
+/// `pncounter` contains the positive-negative counter
+pub mod pncounter;
 
 extern crate rustc_serialize;
 extern crate bincode;

--- a/src/pncounter.rs
+++ b/src/pncounter.rs
@@ -1,0 +1,213 @@
+use std::cmp::{Ordering};
+
+use super::GCounter;
+
+use rustc_serialize::{Encodable, Decodable};
+
+/// `PNCounter` allows the counter to be both incremented and decremented
+/// by representing the increments (P) and the decrements (N) in separate
+/// internal G-Counters.
+///
+/// Merge is implemented by merging the internal P and N counters.
+/// The value of the counter is P minus N.
+///
+/// # Examples
+///
+/// ```
+/// use crdts::PNCounter;
+/// let mut a = PNCounter::new();
+/// a.increment("A".to_string());
+/// a.increment("A".to_string());
+/// a.decrement("A".to_string());
+/// a.increment("A".to_string());
+/// assert_eq!(a.value(), 2);
+/// ```
+
+#[derive(Debug, Eq, Clone, Hash, RustcEncodable, RustcDecodable)]
+pub struct PNCounter<A: Ord + Clone + Encodable + Decodable> {
+    p: GCounter<A>,
+    n: GCounter<A>,
+}
+
+impl<A: Ord + Clone + Encodable + Decodable> Ord for PNCounter<A> {
+    fn cmp(&self, other: &PNCounter<A>) -> Ordering {
+        let (c, oc) = (self.value(), other.value());
+        c.cmp(&oc)
+    }
+}
+
+impl<A: Ord + Clone + Encodable + Decodable> PartialOrd for PNCounter<A> {
+    fn partial_cmp(&self, other: &PNCounter<A>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<A: Ord + Clone + Encodable + Decodable> PartialEq for PNCounter<A> {
+    fn eq(&self, other: &PNCounter<A>) -> bool {
+        let (c, oc) = (self.value(), other.value());
+        c == oc
+    }
+}
+
+impl<A: Ord + Clone + Encodable + Decodable> PNCounter<A> {
+    /// Produces a new `PNCounter`.
+    pub fn new() -> PNCounter<A> {
+        PNCounter {
+            p: GCounter::new(),
+            n: GCounter::new(),
+        }
+    }
+
+    /// Increments a particular actor's counter.
+    pub fn increment(&mut self, actor: A) {
+        self.p.increment(actor);
+    }
+
+    /// Decrements a particular actor's counter.
+    pub fn decrement(&mut self, actor: A) {
+        self.n.increment(actor);
+    }
+
+    /// Returns the current value of this counter (P-N).
+    pub fn value(&self) -> i64 {
+        self.p.value() as i64 - self.n.value() as i64
+    }
+
+    /// Merge another pncounter into this one, without
+    /// regard to dominance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crdts::PNCounter;
+    /// let (mut a, mut b, mut c) = (PNCounter::new(), PNCounter::new(), PNCounter::new());
+    /// a.increment("A".to_string());
+    /// b.increment("B".to_string());
+    /// b.increment("B".to_string());
+    /// b.decrement("A".to_string());
+    /// c.increment("B".to_string());
+    /// c.increment("B".to_string());
+    /// a.merge(b);
+    /// assert_eq!(a, c);
+    pub fn merge(&mut self, other: PNCounter<A>) {
+        self.p.merge(other.p);
+        self.n.merge(other.n);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen, QuickCheck, StdGen};
+    use std::collections::BTreeSet;
+    use rand::{self, Rng};
+
+    use ::GCounter;
+
+    const ACTOR_MAX: u16 = 11;
+    #[derive(Debug, Clone)]
+    enum Op {
+        Increment(i16),
+        Decrement(i16),
+    }
+
+    impl Arbitrary for Op {
+        fn arbitrary<G: Gen>(g: &mut G) -> Op {
+            if g.gen_weighted_bool(2) {
+                Op::Increment(g.gen_range(0, ACTOR_MAX) as i16)
+            } else {
+                Op::Decrement(g.gen_range(0, ACTOR_MAX) as i16)
+            }
+        }
+
+        fn shrink(&self) -> Box<Iterator<Item=Op>> {
+            Box::new(vec![].into_iter())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct OpVec {
+        ops: Vec<Op>,
+    }
+
+    impl Arbitrary for OpVec {
+        fn arbitrary<G: Gen>(g: &mut G )-> OpVec {
+            let mut ops = vec![];
+            for _ in 0..g.gen_range(1, 100) {
+                ops.push(Op::arbitrary(g));
+            }
+            OpVec {
+                ops: ops,
+            }
+        }
+
+        fn shrink(&self) -> Box<Iterator<Item=OpVec>> {
+            let mut smaller = vec![];
+            for i in 0..self.ops.len() {
+                let mut clone = self.clone();
+                clone.ops.remove(i);
+                smaller.push(clone);
+            }
+
+            Box::new(smaller.into_iter())
+        }
+    }
+
+    fn prop_merge_converges(ops: OpVec) -> bool {
+        let mut results = BTreeSet::new();
+
+        // Permute the interleaving of operations should converge.
+        // Largely taken directly from orswot
+        for i in 2..ACTOR_MAX {
+            let mut witnesses: Vec<PNCounter<i16>> = (0..i).map(|_| PNCounter::new()).collect();
+            for op in ops.ops.iter() {
+                match op {
+                    &Op::Increment(actor) => {
+                        witnesses[(actor as usize % i as usize)].increment(actor);
+                    },
+                    &Op::Decrement(actor) => {
+                        witnesses[(actor as usize % i as usize)].decrement(actor);
+                    },
+                }
+            }
+            let mut merged = PNCounter::new();
+            for witness in witnesses.iter() {
+                merged.merge(witness.clone());
+            }
+
+            results.insert(merged.value());
+            if results.len() > 1 {
+                println!("opvec: {:?}", ops);
+                println!("results: {:?}", results);
+                println!("witnesses: {:?}", &witnesses);
+                println!("merged: {:?}", merged);
+            }
+        }
+        results.len() == 1
+    }
+
+
+    #[test]
+    fn qc_merge_converges() {
+        QuickCheck::new()
+                   .gen(StdGen::new(rand::thread_rng(), 1))
+                   .tests(1_000)
+                   .max_tests(10_000)
+                   .quickcheck(prop_merge_converges as fn(OpVec) -> bool);
+    }
+
+
+    #[test]
+    fn test_basic() {
+        let mut a = PNCounter::new();
+        assert_eq!(a.value(), 0);
+        a.increment("A".to_string());
+        assert_eq!(a.value(), 1);
+        a.increment("A".to_string());
+        assert_eq!(a.value(), 2);
+        a.decrement("A".to_string());
+        assert_eq!(a.value(), 1);
+        a.increment("A".to_string());
+        assert_eq!(a.value(), 2);
+    }
+}


### PR DESCRIPTION
Implement the PN-Counter with two G-Counters.

Includes QuickCheck tests for operation interleaving (similar to the tests for orswot).

Also implemented merge for G-Counter to simplify quickcheck test structure for PN-Counter.