### PR TITLE
Cleanup the VClock

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,5 +1,6 @@
 use serde::{Serialize, de::DeserializeOwned};
 use vclock::{Actor, VClock, Dot};
+use traits::CmRDT;
 
 /// ReadCtx's are used to extract data from CRDT's while maintaining some causal history.
 /// You should store ReadCtx's close to where mutation is exposed to the user.

--- a/src/map.rs
+++ b/src/map.rs
@@ -67,7 +67,7 @@ impl<A, T> Val<A> for T where
 /// assert_eq!(friends.get(&"alice".into()).val, None);
 /// assert_eq!(
 ///     friends_replica.get(&"alice".into()).val.map(|set| set.value().val),
-///     Some(vec!["bob".to_string(), "clyde".to_string()])
+///     Some(vec!["bob".to_string(), "clyde".to_string()].into_iter().collect())
 /// );
 ///
 /// // On merge, we should see "alice" in the map but her friend set should only have "clyde".
@@ -76,7 +76,7 @@ impl<A, T> Val<A> for T where
 ///
 /// let alice_friends = friends.get(&"alice".into()).val
 ///     .map(|set| set.value().val);
-/// assert_eq!(alice_friends, Some(vec!["clyde".into()]));
+/// assert_eq!(alice_friends, Some(vec!["clyde".into()].into_iter().collect()));
 /// ```
 #[serde(bound(deserialize = ""))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,7 +89,7 @@ pub struct Map<K: Key, V: Val<A>, A: Actor> {
 }
 
 #[serde(bound(deserialize = ""))]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Entry<V: Val<A>, A: Actor> {
     // The entry clock tells us which actors edited this entry.
     clock: VClock<A>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -145,10 +145,10 @@ impl<K: Key, V: Val<A>, A: Actor> Causal<A> for Map<K, V, A> {
         }
 
         let mut deferred = HashMap::new();
-        for (rm_clock, key) in self.deferred.iter() {
-            let surviving_dots = rm_clock.dominating_vclock(&clock);
-            if !surviving_dots.is_empty() {
-                deferred.insert(surviving_dots, key.clone());
+        for (mut rm_clock, key) in self.deferred.clone().into_iter() {
+            rm_clock.subtract(&clock);
+            if !rm_clock.is_empty() {
+                deferred.insert(rm_clock, key);
             }
         }
         self.deferred = deferred;
@@ -194,41 +194,44 @@ impl<K: Key, V: Val<A>, A: Actor> CvRDT for Map<K, V, A> {
         let mut other_remaining = other.entries.clone();
         let mut keep = BTreeMap::new();
         for (key, mut entry) in self.entries.clone().into_iter() {
-            match other.entries.get(&key) {
+            match other.entries.get(&key).cloned() {
                 None => {
                     // other doesn't contain this entry because it:
                     //  1. has witnessed it and dropped it
                     //  2. hasn't witnessed it
-                    let dom_clock = entry.clock.dominating_vclock(&other.clock);
-                    if dom_clock.is_empty() {
-                        // the other map has witnessed the entry's clock, and dropped this entry
+                    entry.clock.subtract(&other.clock);
+                    if entry.clock.is_empty() {
+                        // other has seen this entry and dropped it
                     } else {
-                        // the other map has not witnessed this add, so add it
-                        let dots_that_this_entry_should_not_have = other.clock.dominating_vclock(&dom_clock);
-                        entry.val.truncate(&dots_that_this_entry_should_not_have);
-                        entry.clock = dom_clock;
+                        // the other map has not seen this entry, so add it
+                        let mut actors_who_have_deleted_this_entry = other.clock.clone();
+                        actors_who_have_deleted_this_entry.subtract(&entry.clock);
+                        entry.val.truncate(&actors_who_have_deleted_this_entry);
                         keep.insert(key, entry);
                     }
                 }
-                Some(other_entry) => {
+                Some(mut other_entry) => {
                     // SUBTLE: this entry is present in both orswots, BUT that doesn't mean we
                     // shouldn't drop it!
                     let common = entry.clock.intersection(&other_entry.clock);
-                    let luniq = entry.clock.dominating_vclock(&common);
-                    let runiq = other_entry.clock.dominating_vclock(&common);
-                    let lkeep = luniq.dominating_vclock(&other.clock);
-                    let rkeep = runiq.dominating_vclock(&self.clock);
+                    entry.clock.subtract(&common);
+                    other_entry.clock.subtract(&common);
+                    entry.clock.subtract(&other.clock);
+                    other_entry.clock.subtract(&self.clock);
+
                     // Perfectly possible that an item in both sets should be dropped
                     let mut common = common;
-                    common.merge(&lkeep);
-                    common.merge(&rkeep);
+                    common.merge(&entry.clock);
+                    common.merge(&other_entry.clock);
+
                     if !common.is_empty() {
                         // we should not drop, as there are common clocks
                         entry.val.merge(&other_entry.val);
-                        let mut merged_clocks = entry.clock.clone();
-                        merged_clocks.merge(&other_entry.clock);
-                        let dots_that_this_entry_should_not_have = merged_clocks.dominating_vclock(&common);
-                        entry.val.truncate(&dots_that_this_entry_should_not_have);
+                        let mut actors_who_have_deleted_this_entry = entry.clock.clone();
+                        actors_who_have_deleted_this_entry.merge(&other_entry.clock);
+                        actors_who_have_deleted_this_entry.subtract(&common);
+
+                        entry.val.truncate(&actors_who_have_deleted_this_entry);
                         entry.clock = common;
                         keep.insert(key.clone(), entry);
                     }
@@ -239,12 +242,12 @@ impl<K: Key, V: Val<A>, A: Actor> CvRDT for Map<K, V, A> {
         }
 
         for (key, mut entry) in other_remaining.into_iter() {
-            let dom_clock = entry.clock.dominating_vclock(&self.clock);
-            if !dom_clock.is_empty() {
+            entry.clock.subtract(&self.clock);
+            if !entry.clock.is_empty() {
                 // other has witnessed a novel addition, so add it
-                let dots_that_this_entry_should_not_have = self.clock.dominating_vclock(&dom_clock);
-                entry.val.truncate(&dots_that_this_entry_should_not_have);
-                entry.clock = dom_clock;
+                let mut actors_who_deleted_this_entry = self.clock.clone();
+                actors_who_deleted_this_entry.subtract(&entry.clock);
+                entry.val.truncate(&actors_who_deleted_this_entry);
                 keep.insert(key, entry);
             }
         }
@@ -331,22 +334,20 @@ impl<K: Key, V: Val<A>, A: Actor> Map<K, V, A> {
 
     /// Apply a key removal given a clock.
     fn apply_rm(&mut self, key: K, clock: &VClock<A>) {
-        if !clock.dominating_vclock(&self.clock).is_empty() {
+        if !(clock <= &self.clock) {
             let deferred_set = self.deferred.entry(clock.clone())
                 .or_insert_with(|| BTreeSet::new());
             deferred_set.insert(key.clone());
         }
 
         if let Some(mut existing_entry) = self.entries.remove(&key) {
-            let dom_clock = existing_entry.clock.dominating_vclock(&clock);
-            if !dom_clock.is_empty() {
-                existing_entry.clock = dom_clock;
+            existing_entry.clock.subtract(&clock);
+            if !existing_entry.clock.is_empty() {
                 existing_entry.val.truncate(&clock);
                 self.entries.insert(key.clone(), existing_entry);
             }
         }
     }
-
 }
 
 #[cfg(test)]

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     //#[ignore]
-    fn qc_mergqe_converges() {
+    fn qc_merge_converges() {
         QuickCheck::new()
             .gen(StdGen::new(rand::thread_rng(), 1))
             .tests(100)

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -191,8 +191,9 @@ impl<M: Member, A: Actor> Orswot<M, A> {
     fn apply_remove(&mut self, member: impl Into<M>, clock: &VClock<A>) {
         let member: M = member.into();
         if !clock.dominating_vclock(&self.clock).is_empty() {
-            let mut deferred_drops =
-                self.deferred.remove(&clock).unwrap_or_else(|| HashSet::new());
+            let mut deferred_drops = self.deferred
+                .remove(&clock)
+                .unwrap_or_else(|| HashSet::new());
             deferred_drops.insert(member.clone());
             self.deferred.insert(clock.clone(), deferred_drops);
         }
@@ -452,7 +453,10 @@ mod tests {
         a.apply(&a_op2);
 
         a.merge(&b);
-        assert_eq!(a.value().val, vec!["element".to_string()].into_iter().collect());
+        assert_eq!(
+            a.value().val,
+            vec!["element".to_string()].into_iter().collect()
+        );
     }
 
     #[test]
@@ -528,7 +532,10 @@ mod tests {
         let b_op = a.add(1, b.value().derive_add_ctx(7));
         b.apply(&b_op);
         a.merge(&b);
-        assert_eq!(a.value().val, vec![1].into_iter().collect());
+        assert_eq!(
+            a.value().val,
+            vec![1].into_iter().collect()
+        );
         let mut expected_clock = VClock::new();
         let op_3 = expected_clock.inc(3);
         let op_7 = expected_clock.inc(7);
@@ -649,9 +656,15 @@ mod tests {
     fn test_dead_node_update() {
         let mut a = Orswot::<u8, u8>::new();
         let a_op = a.add(0, a.value().derive_add_ctx(1));
-        assert_eq!(a_op, super::Op::Add { dot: Dot { actor: 1, counter: 1 }, member: 0 });
+        assert_eq!(
+            a_op,
+            super::Op::Add { dot: Dot { actor: 1, counter: 1 }, member: 0 }
+        );
         a.apply(&a_op);
-        assert_eq!(a.entries.get(&0).unwrap(), &VClock::from(Dot { actor: 1u8, counter: 1 }));
+        assert_eq!(
+            a.entries.get(&0).unwrap(),
+            &VClock::from(Dot { actor: 1u8, counter: 1 })
+        );
 
         let mut b = a.clone();
         let b_op = b.add(1, b.value().derive_add_ctx(2));
@@ -697,6 +710,9 @@ mod tests {
         m2.merge(&snapshot);
 
         assert_eq!(m1, m2);
-        assert_eq!(m1.get(&101).val.unwrap().value().val, vec![2].into_iter().collect());
+        assert_eq!(
+            m1.get(&101).val.unwrap().value().val,
+            vec![2].into_iter().collect()
+        );
     }
 }

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -95,7 +95,7 @@ impl<A: Actor> VClock<A> {
         VClock { dots: BTreeMap::new() }
     }
 
-    /// Truncates to the greatest-lower-bound between the given VClock and self
+    /// Truncates to the greatest-lower-bound of the given VClock and self
     /// ``` rust
     /// use crdts::VClock;
     /// let mut c = VClock::new();

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -92,7 +92,7 @@ impl<A: Actor + Display> Display for VClock<A> {
 impl<A: Actor> Causal<A> for VClock<A> {
     /// Truncates to the greatest-lower-bound of the given VClock and self
     /// ``` rust
-    /// use crdts::VClock;
+    /// use crdts::{VClock, Causal};
     /// let mut c = VClock::new();
     /// c.witness(23, 6);
     /// c.witness(89, 14);
@@ -176,7 +176,7 @@ impl<A: Actor> VClock<A> {
     /// # Examples
     ///
     /// ```
-    /// use crdts::VClock;
+    /// use crdts::{VClock, CmRDT};
     /// let (mut a, mut b) = (VClock::new(), VClock::new());
     /// let a_op1 = a.inc("A".to_string());
     /// a.apply(&a_op1);
@@ -213,7 +213,7 @@ impl<A: Actor> VClock<A> {
     /// # Examples
     ///
     /// ```
-    /// use crdts::VClock;
+    /// use crdts::{VClock, CmRDT};
     /// let (mut a, mut b) = (VClock::new(), VClock::new());
     /// let a_op = a.inc("A".to_string());
     /// a.apply(&a_op);

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -238,50 +238,6 @@ impl<A: Actor> VClock<A> {
         self.dots.is_empty()
     }
 
-    /// Return the dots that self dominates compared to another clock.
-    pub fn dominating_dots(
-        &self,
-        dots: &BTreeMap<A, Counter>,
-    ) -> BTreeMap<A, Counter> {
-        let mut ret = BTreeMap::new();
-        for (actor, counter) in self.dots.iter() {
-            let other = dots.get(actor).map(|c| *c).unwrap_or(0);
-            if *counter > other {
-                ret.insert(actor.clone(), *counter);
-            }
-        }
-        ret
-    }
-
-    /// Return a new `VClock` that contains the entries for which we have
-    /// a counter that dominates another `VClock`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use crdts::VClock;
-    /// let (mut a, mut b) = (VClock::new(), VClock::new());
-    /// a.witness("A".to_string(), 3);
-    /// a.witness("B".to_string(), 2);
-    /// a.witness("D".to_string(), 14);
-    /// a.witness("G".to_string(), 22);
-    ///
-    /// b.witness("A".to_string(), 4);
-    /// b.witness("B".to_string(), 1);
-    /// b.witness("C".to_string(), 1);
-    /// b.witness("D".to_string(), 14);
-    /// b.witness("E".to_string(), 5);
-    /// b.witness("F".to_string(), 2);
-    ///
-    /// let dom = a.dominating_vclock(&b);
-    /// assert_eq!(dom.get(&"B".to_string()), 2);
-    /// assert_eq!(dom.get(&"G".to_string()), 22);
-    /// ```
-    pub fn dominating_vclock(&self, other: &VClock<A>) -> VClock<A> {
-        let dots = self.dominating_dots(&other.dots);
-        VClock { dots: dots }
-    }
-
     /// Returns the common elements (same actor and counter)
     /// for two `VClock` instances.
     pub fn intersection(&self, other: &VClock<A>) -> VClock<A> {
@@ -300,7 +256,7 @@ impl<A: Actor> VClock<A> {
         self.dots.iter()
     }
 
-    /// Remove's actors with descendent dots in the given VClock
+    /// Forget actors who appear in the given VClock with descendent dots
     pub fn subtract(&mut self, other: &VClock<A>) {
         for (actor, counter) in other.iter() {
             if counter >= &self.get(&actor) {

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -95,40 +95,7 @@ impl<A: Actor> VClock<A> {
         VClock { dots: BTreeMap::new() }
     }
 
-    /// Returns the greatest lower bound of given clocks
-    ///
-    /// # Examples
-    ///
-    /// ``` rust
-    /// use crdts::VClock;
-    /// let (mut a, mut b) = (VClock::new(), VClock::new());
-    /// a.witness("A".to_string(), 3);
-    /// a.witness("B".to_string(), 6);
-    /// b.witness("A".to_string(), 2);
-    ///
-    /// let glb = VClock::glb(&a, &b);
-    ///
-    /// assert_eq!(glb.get(&"A".to_string()), 2);
-    /// assert_eq!(glb.get(&"B".to_string()), 0);
-    /// assert!(a >= glb);
-    /// assert!(b >= glb);
-    /// ```
-    pub fn glb(a: &VClock<A>, b: &VClock<A>) -> VClock<A> {
-        let mut glb_vclock = VClock::new();
-        for (actor, a_cntr) in a.dots.iter() {
-            let min_cntr = cmp::min(b.get(actor), *a_cntr);
-            if min_cntr > 0 {
-                // 0 is the implied counter if an actor is not in dots, so we don't
-                // need to waste memory by storing it
-                glb_vclock.dots.insert(actor.clone(), min_cntr);
-            }
-        }
-        glb_vclock
-    }
-
-    /// Truncates the VClock to the greatest-lower-bound of the passed
-    /// in VClock and it's self
-    /// (essentially a mutable version of VClock::glb)
+    /// Truncates to the greatest-lower-bound between the given VClock and self
     /// ``` rust
     /// use crdts::VClock;
     /// let mut c = VClock::new();

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -50,7 +50,7 @@ pub struct Dot<A: Actor> {
 /// or if different replicas are "concurrent" (were mutated in
 /// isolation, and need to be resolved externally).
 #[serde(bound(deserialize = ""))]
-#[derive(Debug, Clone, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VClock<A: Actor> {
     /// dots is the mapping from actors to their associated counters
     pub dots: BTreeMap<A, Counter>,


### PR DESCRIPTION
Addresses #18 #13 #11 

also in this PR:
- remove `VClock::glb` since it's never used.
- replace `VClock::dominating_vclock` with `VClock::subtract`
- remove `VClock::contains_descendent_element`
- replace the `Ord` constraint permeating our types from BTreeMap with `Hash + Eq` and HashMap