### PR TITLE
Add `MaxReg` and `MinReg` registers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,13 @@ pub mod vclock;
 /// This module contains the Dot (Actor + Sequence Number)
 pub mod dot;
 
+/// This module contains a Max Register.
+#[cfg(feature = "num")]
+pub mod maxreg;
+
+/// This module contains a Min Register
+pub mod minreg;
+
 /// This module contains a dense Identifier.
 #[cfg(feature = "num")]
 pub mod identifier;
@@ -66,7 +73,8 @@ mod serde_helper;
 
 #[cfg(feature = "num")]
 pub use {
-    gcounter::GCounter, glist::GList, identifier::Identifier, list::List, pncounter::PNCounter,
+    gcounter::GCounter, glist::GList, identifier::Identifier, list::List, maxreg::MaxReg,
+    minreg::MinReg, pncounter::PNCounter,
 };
 
 // /// Version Vector with Exceptions

--- a/src/maxreg.rs
+++ b/src/maxreg.rs
@@ -6,20 +6,20 @@ use std::convert::Infallible;
 /// you must create a wrapper (or use a crate like `float-ord`)
 /// For modelling as a `CvRDT`:
 /// ```rust
-/// use crdts::{CvRDT,MaxReg}
-/// let mut a = MaxReg{ 3 };
-/// let b = MaxReg{ 2 };
+/// use crdts::{CvRDT,MaxReg};
+/// let mut a = MaxReg{ val: 3 };
+/// let b = MaxReg{ val: 2 };
 ///
 /// a.merge(b);
-/// asserteq!(a.val, 3);
+/// assert_eq!(a.val, 3);
 /// ```
 /// and `CmRDT`:
 /// ```rust
-/// use crdts::{CmRDT, MaxReg}
-/// let mut a = MaxReg{ 3 };
+/// use crdts::{CmRDT, MaxReg};
+/// let mut a = MaxReg{ val: 3 };
 /// let b = 2;
 /// a.apply(b);
-/// asserteq!(a.val, 3)
+/// assert_eq!(a.val, 3);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MaxReg<V> {
@@ -58,7 +58,7 @@ impl<V: Ord> CmRDT for MaxReg<V> {
     type Validation = Infallible;
 
     /// Just returns Ok(())
-    fn validate_op(&self, op: &Self::Op) -> Result<(), Self::Validation> {
+    fn validate_op(&self, _op: &Self::Op) -> Result<(), Self::Validation> {
         Ok(())
     }
 

--- a/src/maxreg.rs
+++ b/src/maxreg.rs
@@ -1,0 +1,135 @@
+use crate::traits::{CmRDT, CvRDT};
+use serde::{Deserialize, Serialize};
+use std::{error, fmt};
+
+/// `MaxReg` Holds a monotonically increasing value that implements the Ord trait. For use of floating-point values,
+/// you must create a wrapper (or use a crate like `float-ord`)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MaxReg<V: Ord + Copy> {
+    /// `val` is the opaque element contained within this CRDT
+    /// Because `val` is monotonic, it also serves as a marker and preserves causality
+    pub val: V,
+}
+
+impl<V: Default + Ord + Copy> Default for MaxReg<V> {
+    fn default() -> Self {
+        Self { val: V::default() }
+    }
+}
+
+/// The Type of validation errors that may occur for an MaxReg.
+#[derive(Debug, PartialEq)]
+pub enum Validation {
+    /// A conflicting change to a MaxReg CRDT is when the value being validated is less-than self.val
+    ConflictingValue,
+}
+
+impl error::Error for Validation {
+    fn description(&self) -> &str {
+        match self {
+            Validation::ConflictingValue => {
+                "Comparison failed! `val` should be monotonically increasing."
+            }
+        }
+    }
+}
+
+impl fmt::Display for Validation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<V: Ord + Copy> CvRDT for MaxReg<V> {
+    type Validation = Validation;
+    /// Validates whether a merge is safe to perfom
+    ///
+    /// Returns an error if `val` is greater than the proposed new value
+    /// ```
+    /// use crdts::{maxreg, MaxReg, CvRDT};
+    /// let mut ub_1 = MaxReg { val: 1};
+    /// let ub_2 = MaxReg { val: 0 };
+    /// // errors!
+    /// assert_eq!(ub_1.validate_merge(&ub_2), Err(maxreg::Validation::ConflictingVal));
+    /// ```
+    fn validate_merge(&self, other: &Self) -> Result<(), Self::Validation> {
+        self.validate_update(&other.val)
+    }
+
+    /// Combines two `MaxReg` instances according to the value that is greatest
+    fn merge(&mut self, MaxReg { val }: Self) {
+        self.update(val)
+    }
+}
+
+impl<V: Ord + Copy> CmRDT for MaxReg<V> {
+    // MaxRegs's are small enough that we can replicate
+    // the entire state as an Op
+    type Op = Self;
+    type Validation = Validation;
+
+    fn validate_op(&self, op: &Self::Op) -> Result<(), Validation> {
+        self.validate_update(&op.val)
+    }
+
+    fn apply(&mut self, op: Self::Op) {
+        self.merge(op)
+    }
+}
+
+impl<V: Ord + Copy> MaxReg<V> {
+    /// Constructs a MaxReg initialized with the specified value `val`.
+    pub fn new(&mut self, val: V) -> Self {
+        MaxReg { val }
+    }
+
+    /// Updates the value of the MaxReg. `val` is always monotonically increasing.
+    pub fn update(&mut self, val: V) {
+        self.val = std::cmp::max(self.val, val);
+    }
+
+    /// Since `val` is a monotonic value, validation is simply to call update
+    pub fn validate_update(&self, val: &V) -> Result<(), Validation> {
+        if &self.val > val {
+            Err(Validation::ConflictingValue)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    /// TODO: I feel like the default should be -Inf??
+    fn test_default() {
+        let reg = MaxReg::default();
+        assert_eq!(reg, MaxReg { val: 0 });
+    }
+
+    #[test]
+    fn test_update() {
+        // Create a `MaxReg` with initial value of 1
+        let mut reg = MaxReg { val: 1 };
+        reg.update(2);
+
+        // normal update: the value of the register increases to some other value
+        // EXPECTED: success, the val is updated since the current value of the register is less than 2
+        assert_eq!(reg, MaxReg { val: 2 });
+
+        // stale update: the value of the register is greater than the incoming one
+        // EXPECTED: success, the val is not updated since the current value is already greater than 1
+        reg.update(1);
+        assert_eq!(reg, MaxReg { val: 2 });
+
+        //bad update: validating an incoming value throws an error
+        //EXPECTED: Err()
+        assert_eq!(reg.validate_update(&1), Err(Validation::ConflictingValue));
+
+        // Applying the update despite the validation error is a no-op (i.e: idempotency)
+        reg.update(1);
+        assert_eq!(reg, MaxReg { val: 2 });
+    }
+}

--- a/src/minreg.rs
+++ b/src/minreg.rs
@@ -1,6 +1,6 @@
 use crate::traits::{CmRDT, CvRDT};
 use serde::{Deserialize, Serialize};
-use std::{error, fmt};
+use std::convert::Infallible;
 
 /// `MinReg` Holds a monotonically decreasing value that implements the Ord trait. For use of floating-point values,
 /// you must create a wrapper (or use a crate like `float-ord`).
@@ -17,57 +17,28 @@ use std::{error, fmt};
 /// ```rust
 /// use crdts::{CmRDT, MinReg}
 /// let mut a = MinReg{ 3 };
-/// let b = MinReg{ 2 };
-/// a.apply(b); // MinReg is also an Op
+/// let b = 2;
+/// a.apply(b);
+/// asserteq!(a.val, 2)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct MinReg<V: Ord + Copy> {
+pub struct MinReg<V> {
     /// `val` is the opaque element contained within this CRDT
     /// Because `val` is monotonic, it also serves as a marker and preserves causality
     pub val: V,
 }
 
-impl<V: Default + Ord + Copy> Default for MinReg<V> {
+impl<V: Default + Ord> Default for MinReg<V> {
     fn default() -> Self {
         Self { val: V::default() }
     }
 }
 
-/// The Type of validation errors that may occur for an MinReg.
-#[derive(Debug, PartialEq)]
-pub enum Validation {
-    /// A conflicting change to a MinReg CRDT is when the value being validated is greater-than self.val
-    ConflictingValue,
-}
+impl<V: Ord> CvRDT for MinReg<V> {
+    /// Validates whether a merge is safe to perfom (it always is)
+    type Validation = Infallible;
 
-impl error::Error for Validation {
-    fn description(&self) -> &str {
-        match self {
-            Validation::ConflictingValue => {
-                "Comparison failed! `val` should be monotonically decreasing."
-            }
-        }
-    }
-}
-
-impl fmt::Display for Validation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl<V: Ord + Copy> CvRDT for MinReg<V> {
-    type Validation = Validation;
-    /// Validates whether a merge is safe to perfom
-    ///
-    /// Returns an error if `val` is greater than the proposed new value
-    /// ```
-    /// use crdts::{minreg, MinReg, CvRDT};
-    /// let mut lb_1 = MinReg { val: 1};
-    /// let lb_2 = MinReg { val: 2 };
-    /// // errors!
-    /// assert_eq!(ub_1.validate_merge(&ub_2), Err(minreg::Validation::ConflictingVal));
-    /// ```
+    /// Always returns Ok(()) since a validation error is Infallible
     fn validate_merge(&self, other: &Self) -> Result<(), Self::Validation> {
         self.validate_update(&other.val)
     }
@@ -78,22 +49,27 @@ impl<V: Ord + Copy> CvRDT for MinReg<V> {
     }
 }
 
-impl<V: Ord + Copy> CmRDT for MinReg<V> {
+impl<V: Ord> CmRDT for MinReg<V> {
     // MinRegs's are small enough that we can replicate
     // the entire state as an Op
-    type Op = Self;
-    type Validation = Validation;
+    type Op = V;
 
-    fn validate_op(&self, op: &Self::Op) -> Result<(), Validation> {
-        self.validate_update(&op.val)
+    // No operation is invalid so we can safely return `Ok(())`
+    type Validation = Infallible;
+
+    /// Just return Ok(())
+    fn validate_op(&self, op: &Self::Op) -> Result<(), Self::Validation> {
+        self.validate_update(&op)
     }
 
     fn apply(&mut self, op: Self::Op) {
-        self.merge(op)
+        // Since type Op = V, we need to wrap MinReg around op.
+        // If more fields are added to the MinReg struct, change Op to Self
+        self.merge(MinReg { val: op })
     }
 }
 
-impl<V: Ord + Copy> MinReg<V> {
+impl<V: Ord> MinReg<V> {
     /// Constructs a MinReg initialized with the specified value `val`.
     pub fn new(&mut self, val: V) -> Self {
         MinReg { val }
@@ -101,17 +77,24 @@ impl<V: Ord + Copy> MinReg<V> {
 
     /// Updates the value of the MinReg. `val` is always monotonically decreasing.
     pub fn update(&mut self, val: V) {
-        self.val = std::cmp::min(self.val, val)
+        if val < self.val {
+            self.val = val
+        }
     }
 
-    /// Since `val` is a monotonic value, validation is simply to call update
-    /// TODO: confirm if this is correct behavior?
-    pub fn validate_update(&self, val: &V) -> Result<(), Validation> {
-        if &self.val < val {
-            Err(Validation::ConflictingValue)
-        } else {
-            Ok(())
-        }
+    /// Generates a write op (i.e: a val: V)
+    pub fn write(&self, val: V) -> <MinReg<V> as CmRDT>::Op {
+        val
+    }
+
+    /// Reads the current value of the registers:
+    pub fn read(&self) -> &V {
+        &self.val
+    }
+
+    /// Since `val` is a monotonic value, validation simply returns Ok(())
+    pub fn validate_update(&self, _val: &V) -> Result<(), Infallible> {
+        Ok(())
     }
 }
 
@@ -141,12 +124,33 @@ mod test {
         reg.update(1);
         assert_eq!(reg, MinReg { val: 0 });
 
-        // bad update: validating an incoming value throws an `ConflictingValue`
-        // EXPECTED: Err()
-        assert_eq!(reg.validate_update(&1), Err(Validation::ConflictingValue));
-
-        // Applying the update despite the validation error is a no-op
-        reg.update(1);
+        // Idempotency: Applying the same update is a no-op
+        // EXPECTED: success, the val is still equal to 0 because 0 ≮ 0
+        reg.update(0);
         assert_eq!(reg, MinReg { val: 0 });
+    }
+    #[test]
+    fn test_read() {
+        // Create a `MinReg` with initial value of 1
+        let reg = MinReg { val: 1 };
+        let val = reg.read();
+        assert_eq!(*val, reg.val);
+    }
+
+    #[test]
+    fn test_write() {
+        // Create a `MinReg` with initial value of 5
+        let a = MinReg { val: 5 };
+
+        // Create a `MinReg` with initial value of 6
+        let mut b = MinReg { val: 6 };
+
+        // Create a write op:
+        let op = b.write(a.val);
+
+        // Apply the op:
+        b.apply(op);
+
+        assert_eq!(b.val, 5);
     }
 }

--- a/src/minreg.rs
+++ b/src/minreg.rs
@@ -6,20 +6,20 @@ use std::convert::Infallible;
 /// you must create a wrapper (or use a crate like `float-ord`).
 /// For modelling as a `CvRDT`:
 /// ```rust
-/// use crdts::{CvRDT,MinReg}
-/// let mut a = MinReg{ 3 };
-/// let b = MinReg{ 2 };
+/// use crdts::{CvRDT,MinReg};
+/// let mut a = MinReg{ val: 3 };
+/// let b = MinReg{ val: 2 };
 ///
 /// a.merge(b);
-/// asserteq!(a.val, 2);
+/// assert_eq!(a.val, 2);
 /// ```
 /// and `CmRDT`:
 /// ```rust
-/// use crdts::{CmRDT, MinReg}
-/// let mut a = MinReg{ 3 };
+/// use crdts::{CmRDT, MinReg};
+/// let mut a = MinReg{ val: 3 };
 /// let b = 2;
 /// a.apply(b);
-/// asserteq!(a.val, 2)
+/// assert_eq!(a.val, 2);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MinReg<V> {

--- a/src/minreg.rs
+++ b/src/minreg.rs
@@ -1,0 +1,152 @@
+use crate::traits::{CmRDT, CvRDT};
+use serde::{Deserialize, Serialize};
+use std::{error, fmt};
+
+/// `MinReg` Holds a monotonically decreasing value that implements the Ord trait. For use of floating-point values,
+/// you must create a wrapper (or use a crate like `float-ord`).
+/// For modelling as a `CvRDT`:
+/// ```rust
+/// use crdts::{CvRDT,MinReg}
+/// let mut a = MinReg{ 3 };
+/// let b = MinReg{ 2 };
+///
+/// a.merge(b);
+/// asserteq!(a.val, 2);
+/// ```
+/// and `CmRDT`:
+/// ```rust
+/// use crdts::{CmRDT, MinReg}
+/// let mut a = MinReg{ 3 };
+/// let b = MinReg{ 2 };
+/// a.apply(b); // MinReg is also an Op
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MinReg<V: Ord + Copy> {
+    /// `val` is the opaque element contained within this CRDT
+    /// Because `val` is monotonic, it also serves as a marker and preserves causality
+    pub val: V,
+}
+
+impl<V: Default + Ord + Copy> Default for MinReg<V> {
+    fn default() -> Self {
+        Self { val: V::default() }
+    }
+}
+
+/// The Type of validation errors that may occur for an MinReg.
+#[derive(Debug, PartialEq)]
+pub enum Validation {
+    /// A conflicting change to a MinReg CRDT is when the value being validated is greater-than self.val
+    ConflictingValue,
+}
+
+impl error::Error for Validation {
+    fn description(&self) -> &str {
+        match self {
+            Validation::ConflictingValue => {
+                "Comparison failed! `val` should be monotonically decreasing."
+            }
+        }
+    }
+}
+
+impl fmt::Display for Validation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<V: Ord + Copy> CvRDT for MinReg<V> {
+    type Validation = Validation;
+    /// Validates whether a merge is safe to perfom
+    ///
+    /// Returns an error if `val` is greater than the proposed new value
+    /// ```
+    /// use crdts::{minreg, MinReg, CvRDT};
+    /// let mut lb_1 = MinReg { val: 1};
+    /// let lb_2 = MinReg { val: 2 };
+    /// // errors!
+    /// assert_eq!(ub_1.validate_merge(&ub_2), Err(minreg::Validation::ConflictingVal));
+    /// ```
+    fn validate_merge(&self, other: &Self) -> Result<(), Self::Validation> {
+        self.validate_update(&other.val)
+    }
+
+    /// Combines two `MinReg` instances according to the value that is smallest
+    fn merge(&mut self, MinReg { val }: Self) {
+        self.update(val)
+    }
+}
+
+impl<V: Ord + Copy> CmRDT for MinReg<V> {
+    // MinRegs's are small enough that we can replicate
+    // the entire state as an Op
+    type Op = Self;
+    type Validation = Validation;
+
+    fn validate_op(&self, op: &Self::Op) -> Result<(), Validation> {
+        self.validate_update(&op.val)
+    }
+
+    fn apply(&mut self, op: Self::Op) {
+        self.merge(op)
+    }
+}
+
+impl<V: Ord + Copy> MinReg<V> {
+    /// Constructs a MinReg initialized with the specified value `val`.
+    pub fn new(&mut self, val: V) -> Self {
+        MinReg { val }
+    }
+
+    /// Updates the value of the MinReg. `val` is always monotonically decreasing.
+    pub fn update(&mut self, val: V) {
+        self.val = std::cmp::min(self.val, val)
+    }
+
+    /// Since `val` is a monotonic value, validation is simply to call update
+    /// TODO: confirm if this is correct behavior?
+    pub fn validate_update(&self, val: &V) -> Result<(), Validation> {
+        if &self.val < val {
+            Err(Validation::ConflictingValue)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    /// TODO: I feel like the default should be Inf??
+    fn test_default() {
+        let reg = MinReg::default();
+        assert_eq!(reg, MinReg { val: 0 });
+    }
+
+    #[test]
+    fn test_update() {
+        // Create a `MinReg` with initial value of 1
+        let mut reg = MinReg { val: 1 };
+        reg.update(0);
+
+        // normal update: the value of the register decreases to some other value
+        // EXPECTED: success, the val is updated since the current value of the register is greater than 0
+        assert_eq!(reg, MinReg { val: 0 });
+
+        // stale update: the value of the register is less than the incoming one
+        // EXPECTED: success, the val is not updated since the current value is already less than 1
+        reg.update(1);
+        assert_eq!(reg, MinReg { val: 0 });
+
+        // bad update: validating an incoming value throws an `ConflictingValue`
+        // EXPECTED: Err()
+        assert_eq!(reg.validate_update(&1), Err(Validation::ConflictingValue));
+
+        // Applying the update despite the validation error is a no-op
+        reg.update(1);
+        assert_eq!(reg, MinReg { val: 0 });
+    }
+}


### PR DESCRIPTION
This PR comes from the following discussion: https://github.com/rust-crdt/rust-crdt/discussions/145#discussion-6521462. `MaxReg` and `MinReg` CRDTs track a monotonically increasing or decreasing value respectively. The struct has a single field called `val` to maintain consistent format with the `LWWReg` CRDT, which has fields `val` and `marker`. `MaxReg` and `MinReg` do not need a `marker` as they are monotonic values and can technically be considered a `marker`.  The single field `val` is preferred to `pub struct<V: Ord + Copy> MinReg(V)` as it is clear what the struct contains and will allow adding any other fields in the future. A field that might be interesting to add could be `bound` which acts as an upper/lower bound  on the opaque value stored `val`. This could be used as a convenient termination signal or as a way to test whether distributed replicas of a `MinReg` or `MaxReg` have reached some agreed upon state etc...