### PR TITLE
No std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ name = "test"
 path = "test/test.rs"
 
 [features]
-default = ["quickcheck", "num", "merkle"]
+default = ["quickcheck", "num", "merkle", "std"]
+std = []
 quickcheck = ["dep:quickcheck"]
 num = ["dep:num"]
 merkle = ["dep:tiny-keccak"]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,6 +1,8 @@
-use std::cmp::{Ordering, PartialOrd};
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::{Ordering, PartialOrd};
+use core::fmt;
+use core::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
@@ -145,7 +147,7 @@ impl<A: fmt::Debug> fmt::Display for DotRange<A> {
     }
 }
 
-impl<A: fmt::Debug> std::error::Error for DotRange<A> {}
+impl<A: fmt::Debug> core::error::Error for DotRange<A> {}
 
 #[cfg(all(test, feature = "quickcheck"))]
 mod test {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,5 +1,3 @@
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::cmp::{Ordering, PartialOrd};
 use core::fmt;
 use core::hash::{Hash, Hasher};
@@ -77,23 +75,27 @@ impl<A> From<(A, u64)> for Dot<A> {
 }
 
 #[cfg(feature = "quickcheck")]
-use quickcheck::{Arbitrary, Gen};
+mod check {
+    use super::*;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
+    use quickcheck::{Arbitrary, Gen};
 
-#[cfg(feature = "quickcheck")]
-impl<A: Arbitrary + Clone> Arbitrary for Dot<A> {
-    fn arbitrary(g: &mut Gen) -> Self {
-        Dot {
-            actor: A::arbitrary(g),
-            counter: u64::arbitrary(g) % 50,
+    impl<A: Arbitrary + Clone> Arbitrary for Dot<A> {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Dot {
+                actor: A::arbitrary(g),
+                counter: u64::arbitrary(g) % 50,
+            }
         }
-    }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        let mut shrunk_dots = Vec::new();
-        if self.counter > 0 {
-            shrunk_dots.push(Self::new(self.actor.clone(), self.counter - 1));
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            let mut shrunk_dots = Vec::new();
+            if self.counter > 0 {
+                shrunk_dots.push(Self::new(self.actor.clone(), self.counter - 1));
+            }
+            Box::new(shrunk_dots.into_iter())
         }
-        Box::new(shrunk_dots.into_iter())
     }
 }
 

--- a/src/glist.rs
+++ b/src/glist.rs
@@ -1,10 +1,10 @@
 //! # GList - Grow-only List CRDT
 
+use alloc::collections::BTreeSet;
 use core::convert::Infallible;
 use core::fmt;
 use core::iter::FromIterator;
 use core::ops::Bound::*;
-use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
@@ -69,7 +69,7 @@ impl<T: Ord + Clone> GList<T> {
     }
 
     /// Iterate over the elements of the list
-    pub fn iter(&self) -> std::collections::btree_set::Iter<Identifier<T>> {
+    pub fn iter(&self) -> alloc::collections::btree_set::Iter<Identifier<T>> {
         self.list.iter()
     }
 

--- a/src/gset.rs
+++ b/src/gset.rs
@@ -1,5 +1,5 @@
+use alloc::collections::BTreeSet;
 use core::convert::Infallible;
-use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -8,6 +8,9 @@
 //!
 //! The GList and List CRDT's rely on this property so that we may always insert elements
 //! between any existing elements.
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 
@@ -85,9 +88,9 @@ impl<T: Clone + Ord + Eq> Identifier<T> {
 
                 let mut path: Vec<(BigRational, T)> = vec![];
 
-                let mut low_path: Box<dyn std::iter::Iterator<Item = &(BigRational, T)>> =
+                let mut low_path: Box<dyn core::iter::Iterator<Item = &(BigRational, T)>> =
                     Box::new(low.0.iter());
-                let mut high_path: Box<dyn std::iter::Iterator<Item = &(BigRational, T)>> =
+                let mut high_path: Box<dyn core::iter::Iterator<Item = &(BigRational, T)>> =
                     Box::new(high.0.iter());
                 loop {
                     match (low_path.next(), high_path.next()) {
@@ -104,7 +107,7 @@ impl<T: Clone + Ord + Eq> Identifier<T> {
                                 // Otherwise, the two paths have diverged.
                                 // Choose one path and clear out the other.
                                 path.push((h_ratio.clone(), h_m.clone()));
-                                low_path = Box::new(std::iter::empty());
+                                low_path = Box::new(core::iter::empty());
                             }
                         }
                         (low_node, high_node) => {
@@ -168,9 +171,9 @@ impl<T: Arbitrary> Arbitrary for Identifier<T> {
         let mut path = self.0.clone();
         let last_elem_opt = path.pop();
         if last_elem_opt.is_some() {
-            Box::new(std::iter::once(Self(path)))
+            Box::new(core::iter::once(Self(path)))
         } else {
-            Box::new(std::iter::empty())
+            Box::new(core::iter::empty())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,12 @@
 //! operations.
 //!
 //! [crdt]: https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type
+#![cfg_attr(not(feature = "std"), no_std)]
 #![crate_type = "lib"]
 #![deny(missing_docs)]
 #![deny(unreachable_pub)]
+
+extern crate alloc;
 
 mod traits;
 pub use crate::traits::{Actor, CmRDT, CvRDT, ResetRemove};
@@ -82,9 +85,11 @@ pub use {
 
 /// Top-level re-exports for CRDT structures.
 pub use crate::{
-    dot::Dot, dot::DotRange, dot::OrdDot, gset::GSet, lwwreg::LWWReg, map::Map, mvreg::MVReg,
-    orswot::Orswot, vclock::VClock,
+    dot::Dot, dot::DotRange, dot::OrdDot, gset::GSet, lwwreg::LWWReg, mvreg::MVReg, vclock::VClock,
 };
+
+#[cfg(feature = "std")]
+pub use crate::{map::Map, orswot::Orswot};
 
 /// A re-export of the quickcheck crate for external property tests
 #[cfg(feature = "quickcheck")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod minreg;
 pub mod identifier;
 
 /// This module contains an Observed-Remove Set With Out Tombstones.
+#[cfg(feature = "std")]
 pub mod orswot;
 
 /// This module contains a Grow-only Counter.
@@ -63,6 +64,7 @@ pub mod glist;
 pub mod pncounter;
 
 /// This module contains a Map with Reset-Remove and Observed-Remove semantics.
+#[cfg(feature = "std")]
 pub mod map;
 
 /// This module contains context for editing a CRDT.
@@ -72,6 +74,7 @@ pub mod ctx;
 #[cfg(feature = "num")]
 pub mod list;
 
+#[cfg(any(feature = "num", feature = "merkle"))]
 mod serde_helper;
 
 #[cfg(feature = "num")]

--- a/src/list.rs
+++ b/src/list.rs
@@ -40,9 +40,9 @@
 //! in 2009 29th IEEE International Conference on Distributed Computing Systems,
 //! Montreal, Quebec, Canada, Jun. 2009, pp. 404–412, doi: 10.1109/ICDCS.2009.75.
 
+use alloc::collections::BTreeMap;
 use core::fmt;
 use core::iter::FromIterator;
-use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -285,7 +285,7 @@ impl<T: SerDe, A: Ord + Clone + fmt::Debug> CmRDT for List<T, A> {
 impl<T: SerDe, A: Ord> IntoIterator for List<T, A> {
     type Item = T;
 
-    type IntoIter = std::collections::btree_map::IntoValues<Identifier<OrdDot<A>>, T>;
+    type IntoIter = alloc::collections::btree_map::IntoValues<Identifier<OrdDot<A>>, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.seq.into_values()

--- a/src/lwwreg.rs
+++ b/src/lwwreg.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use core::{error, fmt};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,9 +1,9 @@
-use std::cmp::Ordering;
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Display};
+use core::hash::Hash;
+use core::mem;
 use std::collections::HashMap;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{self, Debug, Display};
-use std::hash::Hash;
-use std::mem;
 
 use serde::{Deserialize, Serialize};
 
@@ -134,7 +134,7 @@ impl<V: CmRDT + Debug, A: Debug> Display for CmRDTValidation<V, A> {
     }
 }
 
-impl<V: CmRDT + Debug, A: Debug> std::error::Error for CmRDTValidation<V, A> {}
+impl<V: CmRDT + Debug, A: Debug> core::error::Error for CmRDTValidation<V, A> {}
 
 /// The various validation errors that may occur when using a Map CRDT.
 #[derive(Debug, PartialEq, Eq)]
@@ -160,7 +160,7 @@ impl<K: Debug, V: CvRDT + Debug, A: Debug> Display for CvRDTValidation<K, V, A> 
     }
 }
 
-impl<K: Debug, V: CvRDT + Debug, A: Debug> std::error::Error for CvRDTValidation<K, V, A> {}
+impl<K: Debug, V: CvRDT + Debug, A: Debug> core::error::Error for CvRDTValidation<K, V, A> {}
 
 impl<K: Ord, V: Val<A> + Debug, A: Ord + Hash + Clone + Debug> CmRDT for Map<K, V, A> {
     type Op = Op<K, V, A>;

--- a/src/maxreg.rs
+++ b/src/maxreg.rs
@@ -1,6 +1,6 @@
 use crate::traits::{CmRDT, CvRDT};
+use core::convert::Infallible;
 use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
 
 /// `MaxReg` Holds a monotonically increasing value that implements the Ord trait. For use of floating-point values,
 /// you must create a wrapper (or use a crate like `float-ord`)

--- a/src/merkle_reg.rs
+++ b/src/merkle_reg.rs
@@ -1,6 +1,7 @@
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
 use core::convert::Infallible;
 use core::fmt;
-use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
@@ -191,7 +192,7 @@ impl fmt::Display for ValidationError {
     }
 }
 
-impl std::error::Error for ValidationError {}
+impl core::error::Error for ValidationError {}
 
 impl<T: Sha3Hash + SerDe> CmRDT for MerkleReg<T> {
     type Op = Node<T>;

--- a/src/minreg.rs
+++ b/src/minreg.rs
@@ -1,6 +1,6 @@
 use crate::traits::{CmRDT, CvRDT};
+use core::convert::Infallible;
 use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
 
 /// `MinReg` Holds a monotonically decreasing value that implements the Ord trait. For use of floating-point values,
 /// you must create a wrapper (or use a crate like `float-ord`).

--- a/src/mvreg.rs
+++ b/src/mvreg.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::convert::Infallible;
 use core::fmt::{self, Debug, Display};

--- a/src/orswot.rs
+++ b/src/orswot.rs
@@ -1,9 +1,11 @@
 /// Observed-Remove Set With Out Tombstones (ORSWOT), ported directly from `riak_dt`.
-use std::cmp::Ordering;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt::{Debug, Display};
+use core::hash::Hash;
+use core::mem;
 use std::collections::{HashMap, HashSet};
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
-use std::mem;
 
 use serde::{Deserialize, Serialize};
 
@@ -101,12 +103,12 @@ pub enum Validation<M, A> {
 }
 
 impl<M: Debug, A: Debug> Display for Validation<M, A> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(&self, f)
     }
 }
 
-impl<M: Debug, A: Debug> std::error::Error for Validation<M, A> {}
+impl<M: Debug, A: Debug> core::error::Error for Validation<M, A> {}
 
 impl<M: Hash + Eq + Clone + Debug, A: Ord + Hash + Clone + Debug> CvRDT for Orswot<M, A> {
     type Validation = Validation<M, A>;
@@ -243,7 +245,7 @@ impl<M: Hash + Clone + Eq, A: Ord + Hash + Clone> Orswot<M, A> {
     pub fn add(&self, member: M, ctx: AddCtx<A>) -> Op<M, A> {
         Op::Add {
             dot: ctx.dot,
-            members: std::iter::once(member).collect(),
+            members: core::iter::once(member).collect(),
         }
     }
 
@@ -259,7 +261,7 @@ impl<M: Hash + Clone + Eq, A: Ord + Hash + Clone> Orswot<M, A> {
     pub fn rm(&self, member: M, ctx: RmCtx<A>) -> Op<M, A> {
         Op::Rm {
             clock: ctx.clock,
-            members: std::iter::once(member).collect(),
+            members: core::iter::once(member).collect(),
         }
     }
 
@@ -433,7 +435,7 @@ impl<A: Ord + Hash + Arbitrary + Debug, M: Hash + Eq + Arbitrary> Arbitrary for 
 }
 
 impl<M: Debug, A: Ord + Hash + Debug> Debug for Op<M, A> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Op::Add { dot, members } => write!(f, "Add({:?}, {:?})", dot, members),
             Op::Rm { clock, members } => write!(f, "Rm({:?}, {:?})", clock, members),

--- a/src/pncounter.rs
+++ b/src/pncounter.rs
@@ -1,6 +1,6 @@
+use core::fmt::Debug;
 use num::bigint::BigInt;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 use crate::traits::{CmRDT, CvRDT, ResetRemove};
 use crate::{Dot, GCounter, VClock};
@@ -190,7 +190,8 @@ mod test {
     #[cfg(feature = "quickcheck")]
     mod prop_tests {
         use super::*;
-        use std::collections::BTreeSet;
+        use alloc::collections::BTreeSet;
+        use alloc::vec::Vec;
 
         use quickcheck_macros::quickcheck;
 

--- a/src/serde_helper.rs
+++ b/src/serde_helper.rs
@@ -4,8 +4,9 @@ pub trait SerDe: Serialize + DeserializeOwned {}
 impl<T: Serialize + DeserializeOwned> SerDe for T {}
 
 pub(crate) mod btreemap_as_vec {
+    use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::collections::BTreeMap;
 
     pub(crate) fn serialize<S, K, V>(v: &BTreeMap<K, V>, s: S) -> Result<S::Ok, S::Error>
     where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
-use std::hash::Hash;
+use core::error::Error;
+use core::hash::Hash;
 
 use crate::VClock;
 

--- a/src/vclock.rs
+++ b/src/vclock.rs
@@ -12,11 +12,13 @@
 //! assert!(a > b);
 //! ```
 
+use alloc::boxed::Box;
+use alloc::collections::{btree_map, BTreeMap};
+use alloc::vec::Vec;
 use core::cmp::{self, Ordering};
 use core::convert::Infallible;
 use core::fmt::{self, Debug, Display};
 use core::mem;
-use std::collections::{btree_map, BTreeMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -282,7 +284,7 @@ pub struct IntoIter<A: Ord> {
     btree_iter: btree_map::IntoIter<A, u64>,
 }
 
-impl<A: Ord> std::iter::Iterator for IntoIter<A> {
+impl<A: Ord> core::iter::Iterator for IntoIter<A> {
     type Item = Dot<A>;
 
     fn next(&mut self) -> Option<Dot<A>> {
@@ -292,7 +294,7 @@ impl<A: Ord> std::iter::Iterator for IntoIter<A> {
     }
 }
 
-impl<A: Ord> std::iter::IntoIterator for VClock<A> {
+impl<A: Ord> core::iter::IntoIterator for VClock<A> {
     type Item = Dot<A>;
     type IntoIter = IntoIter<A>;
 
@@ -304,7 +306,7 @@ impl<A: Ord> std::iter::IntoIterator for VClock<A> {
     }
 }
 
-impl<A: Ord + Clone + Debug> std::iter::FromIterator<Dot<A>> for VClock<A> {
+impl<A: Ord + Clone + Debug> core::iter::FromIterator<Dot<A>> for VClock<A> {
     fn from_iter<I: IntoIterator<Item = Dot<A>>>(iter: I) -> Self {
         let mut clock = VClock::default();
 


### PR DESCRIPTION
Switch std imports to core or alloc where possible. Add std feature which defaults on. Modules map and orswot are gated behind std. Everything else works with no other changes.

map and orswot could be supported in no_std if the std hashmap was replaced with hashbrown's hashmap, but I figured I'd make the more conservative change first.

This PR currently requires nightly for error in core which will stabilize in 1.81, this is why the PR is marked draft. The error related parts of this PR could be gated behind a nightly feature and then be merged now, but I don't think there's a rush and the PR can just wait till 1.81 is released.